### PR TITLE
Make sender and receiver composite primary keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'devise'
 
+gem 'composite_primary_keys'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    composite_primary_keys (11.3.1)
+      activerecord (~> 5.2.4)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     devise (4.7.1)
@@ -239,6 +241,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.2)
+  composite_primary_keys
   devise
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,7 @@ class FriendshipsController < ApplicationController
   # POST /friendships
   # POST /friendships.json
   def create
-    @friendship = Friendship.new(sender_id: params[:sender], receiver_id: params[:receiver], status: 'requested')
+    @friendship = Friendship.new(sender_id: params[:sender], receiver_id: params[:receiver])
 
     if @friendship.save
       flash[:notice] = 'Friendship was successfully created.'
@@ -32,12 +32,13 @@ class FriendshipsController < ApplicationController
     redirect_to user_path(params[:receiver])
   end
 
-  def re_create
+  def destroy_both
     @friendship = Friendship.where(sender_id: params[:receiver], receiver_id: params[:sender]).first
     if @friendship.destroy
-      create
+      puts('>>>>>>>>>>>>>>>>>>First')
+      destroy
     else
-      flash[:alert] = 'Friendship not created!'
+      flash[:alert] = 'Friendship not removed!'
       redirect_to user_path(params[:receiver])
     end
   end
@@ -61,6 +62,7 @@ class FriendshipsController < ApplicationController
     @friendship = Friendship.where(sender_id: params[:sender], receiver_id: params[:receiver]).first
 
     if @friendship.destroy
+      puts('>>>>>>>>>>>>>>>>>>Second')
       flash[:notice] = 'Friendship was successfully removed.'
     else
       flash[:alert] = 'Friendship not removed!'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,8 +20,8 @@ class PostsController < ApplicationController
   private
 
   def timeline_posts
-    friends = current_user.sent_requests.where(status: 'accepted').pluck(:receiver_id).to_a
-    friends += current_user.received_requests.where(status: 'accepted').pluck(:sender_id).to_a
+    friends = current_user.sent_requests.pluck(:receiver_id).to_a
+    friends += current_user.received_requests.pluck(:sender_id).to_a
     friends.push(current_user[:id])
     @timeline_posts ||= Post.where(user_id: friends).ordered_by_most_recent.includes(:user)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,8 +20,9 @@ class PostsController < ApplicationController
   private
 
   def timeline_posts
-    friends = current_user.sent_requests.pluck(:receiver_id).to_a
-    friends += current_user.received_requests.pluck(:sender_id).to_a
+    sent_requests = current_user.sent_requests.pluck(:receiver_id).to_a
+    received_requests = current_user.received_requests.pluck(:sender_id).to_a
+    friends = sent_requests & received_requests
     friends.push(current_user[:id])
     @timeline_posts ||= Post.where(user_id: friends).ordered_by_most_recent.includes(:user)
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/LineLength
 module UsersHelper
   def request_sent?
     @user.received_requests.any? { |request| (request.sender_id == current_user[:id]) }
@@ -11,4 +12,24 @@ module UsersHelper
     @user = user
     !request_sent? && !request_received? && user != current_user
   end
+
+  def friendship_message
+    message = ''
+    if @user.id != current_user[:id]
+      if request_sent? && request_received?
+        message << '<div>Your Friend.</div>'
+        message << "<%= link_to 'Remove as friend', :controller => 'friendships', :action => 'destroy_both', :sender => current_user, :receiver => @user, :redirect_user => @user %>"
+      elsif request_sent?
+        message << "<%= link_to 'Cancel friend request', :controller => 'friendships', :action => 'destroy', :sender => current_user, :receiver => @user, :redirect_user => @user %>"
+      elsif request_received?
+        message << '<div>You have been requested as friend.</div>'
+        message << "<%= link_to 'Accept request', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %><br />"
+        message << "<%= link_to 'Decline request', :controller => 'friendships', :action => 'destroy', :sender => @user, :receiver => current_user, :redirect_user => @user %>"
+      else
+        message << "<%= link_to 'Add as friend', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %>"
+      end
+    end
+    render inline: message
+  end
 end
+# rubocop:enable Metrics/LineLength

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,22 +1,10 @@
 module UsersHelper
   def request_sent?
-    @user.received_requests.each do |request|
-      if request.sender_id == current_user[:id]
-        @sent_request = request
-        return true
-      end
-    end
-    false
+    @user.received_requests.any? { |request| (request.sender_id == current_user[:id]) }
   end
 
   def request_received?
-    @user.sent_requests.each do |request|
-      if request.receiver_id == current_user[:id]
-        @received_request = request
-        return true
-      end
-    end
-    false
+    @user.sent_requests.any? { |request| (request.receiver_id == current_user[:id]) }
   end
 
   def no_request?(user)

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,4 +1,5 @@
 class Friendship < ApplicationRecord
+  self.primary_keys = :sender_id, :receiver_id
   validates_uniqueness_of :sender_id, scope: [:receiver_id]
   belongs_to :sender, class_name: 'User'
   belongs_to :receiver, class_name: 'User'

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,6 @@
 <section class="user-section">
   <h2><%= "Name: #{@user.name}" %></h2>
-  <% if @user.id != current_user[:id] %>
-    <% if request_sent? && request_received? %>
-      <div>Your Friend.</div>
-      <%= link_to 'Remove as friend', :controller => 'friendships', :action => 'destroy_both', :sender => current_user, :receiver => @user, :redirect_user => @user %>
-    <% elsif request_sent? %>
-      <%= link_to 'Cancel friend request', :controller => 'friendships', :action => 'destroy', :sender => current_user, :receiver => @user, :redirect_user => @user %>
-    <% elsif request_received? %>
-      <div>You have been requested as friend.</div>
-      <%= link_to 'Accept request', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %><br />
-      <%= link_to 'Decline request', :controller => 'friendships', :action => 'destroy', :sender => @user, :receiver => current_user, :redirect_user => @user %>
-    <% else %>
-      <%= link_to 'Add as friend', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %>
-    <% end %>
-  <% end %>
+  <%= friendship_message %>
   <article class="timeline">
     <h3>Recent posts:</h3>
     <ul class="posts">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,26 +1,15 @@
 <section class="user-section">
   <h2><%= "Name: #{@user.name}" %></h2>
   <% if @user.id != current_user[:id] %>
-    <% if request_sent? %>
-      <% if @sent_request[:status] == 'requested' %>
-        <%= link_to 'Cancel friend request', :controller => 'friendships', :action => 'destroy', :sender => current_user, :receiver => @user, :redirect_user => @user %>
-      <% elsif @sent_request[:status] == 'accepted' %>
-        <div>Your Friend.</div>
-        <%= link_to 'Remove as friend', :controller => 'friendships', :action => 'destroy', :sender => current_user, :receiver => @user, :redirect_user => @user %>
-      <% elsif @sent_request[:status] == 'declined' %>
-        <div>Friendship Declined</div>
-      <% end %>
+    <% if request_sent? && request_received? %>
+      <div>Your Friend.</div>
+      <%= link_to 'Remove as friend', :controller => 'friendships', :action => 'destroy_both', :sender => current_user, :receiver => @user, :redirect_user => @user %>
+    <% elsif request_sent? %>
+      <%= link_to 'Cancel friend request', :controller => 'friendships', :action => 'destroy', :sender => current_user, :receiver => @user, :redirect_user => @user %>
     <% elsif request_received? %>
-      <% if @received_request[:status] == 'requested' %>
-        <div>You have been requested as friend.</div>
-        <%= link_to 'Accept request', :controller => 'friendships', :action => 'update', :sender => @user, :receiver => current_user, :status=> 'accepted' %><br />
-        <%= link_to 'Decline request', :controller => 'friendships', :action => 'update', :sender => @user, :receiver => current_user, :status=> 'declined' %>
-      <% elsif @received_request[:status] == 'accepted' %>
-        <div>Your Friend.</div>
-        <%= link_to 'Remove as friend', :controller => 'friendships', :action => 'destroy', :sender => @user, :receiver => current_user, :redirect_user => @user %>
-      <% elsif @received_request[:status] == 'declined' %>
-        <%= link_to 'Add as friend', :controller => 'friendships', :action => 're_create', :sender => current_user, :receiver => @user %>
-      <% end %>
+      <div>You have been requested as friend.</div>
+      <%= link_to 'Accept request', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %><br />
+      <%= link_to 'Decline request', :controller => 'friendships', :action => 'destroy', :sender => @user, :receiver => current_user, :redirect_user => @user %>
     <% else %>
       <%= link_to 'Add as friend', :controller => 'friendships', :action => 'create', :sender => current_user, :receiver => @user %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   # resources :friendships, only: [:create]
-  get 'friendships/re_create'
+  get 'friendships/destroy_both'
   get 'friendships/create'
   get 'friendships/destroy'
   get 'friendships/update'

--- a/db/migrate/20210202153424_remove_id_from_friendship.rb
+++ b/db/migrate/20210202153424_remove_id_from_friendship.rb
@@ -1,0 +1,8 @@
+class RemoveIdFromFriendship < ActiveRecord::Migration[5.2]
+  def change
+    execute "ALTER TABLE friendships DROP CONSTRAINT friendships_pkey"
+    execute "ALTER TABLE friendships ADD PRIMARY KEY (sender_id,receiver_id);"
+    remove_column :friendships, :status
+    remove_column :friendships, :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_29_093852) do
+ActiveRecord::Schema.define(version: 2021_02_02_153424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,10 +25,9 @@ ActiveRecord::Schema.define(version: 2021_01_29_093852) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "friendships", force: :cascade do |t|
-    t.integer "sender_id"
-    t.integer "receiver_id"
-    t.string "status"
+  create_table "friendships", primary_key: ["sender_id", "receiver_id"], force: :cascade do |t|
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Friendship, type: :model do
   let(:user) { User.new(name: 'John', email: 'john@mail.com', password: 'password') }
   let(:friend) { User.new(name: 'Tim', email: 'tim@mail.com', password: 'password') }
-  let(:friendship) { Friendship.create(sender: user, receiver: friend, status: 'requested') }
+  let(:friendship) { Friendship.create(sender: user, receiver: friend) }
 
   it 'creates a valid friendship' do
     expect(friendship.valid?).to be true
@@ -18,7 +18,7 @@ RSpec.describe Friendship, type: :model do
   end
 
   it 'creates a friendship through user' do
-    new_friendship = user.sent_requests.build(sender: user, receiver: friend, status: 'requested')
+    new_friendship = user.sent_requests.build(sender: user, receiver: friend)
     expect(new_friendship.valid?).to be true
   end
 end


### PR DESCRIPTION
In this feature the following have been done:

- `sender_id` and `receiver_id` have been made composite primary keys for `friendship` table
- `id` and `status` have been removed from `friendship` table

Thank You.